### PR TITLE
Fix bug: display the correct reply based on the reply number after the link

### DIFF
--- a/v2ex_reply.js
+++ b/v2ex_reply.js
@@ -411,7 +411,7 @@ _reply_link.mouseenter(function(){
         display_foMouse = setTimeout(function(){
             _close_reply.html( "<div style='padding-bottom:6px;'>" + (1) + "层至" + (_no) + "层间未发现该用户的回复</div>" + "<img class='triangle' src='"+ triangle_img +"' />" );
             // 判断 @ 之后是否跟了 # 号
-            var result = RegExp("@" + _this.text() + " #(\\d+)").exec(_this.parent().text());
+            var result = RegExp(" #(\\d+)").exec(_this[0].nextSibling.data);
             if (result && _reply_user_name_list[+result[1]] == _this.text()){
                 var i = +result[1];
                 _close_reply.html( _reply_content_list[i] + "<p class='bubbleName' style='text-align:right; padding-right:0px;'>\


### PR DESCRIPTION
When the content is referring to two or more replies, the pop up display always shows the first reply that is referred in the content. For example,

```
@someuser #1 
@someuser #2
```

If you hover over the second hyperlink, the reply at level 1 will be displayed, not the reply in level 2. This pull request fixes this bug by searching for the level that is referred to from the text following the link (i.e. `nextSibling`), not the entire content (i.e. `parent`).

You can use https://www.v2ex.com/t/579620?p=1#r_7570560 as a test case.