### PR TITLE
Add image parser of reply

### DIFF
--- a/page/options.html
+++ b/page/options.html
@@ -184,6 +184,18 @@
                 </div>
               </label>
             </li>
+            <li>
+                <label class="item">
+                    <div class="item-content">图片解析<div class="item-content-tip">重新解析图片，目前支持 3 种方式：图片URL、![]()、&lt;img /&gt;</div></div>
+                    <div class="item-secondary dropdownMenu">
+                        <select name="imageParsing" id="imageParsing">
+                            <option value="auto-hide">自动隐藏原始回复（默认）</option>
+                            <option value="always-display">始终显示原始回复</option>
+                            <option value="off">关闭此功能</option>
+                        </select>
+                    </div>
+                </label>
+            </li>
           </ul>
         </div>
       <!--------------其他-------------->

--- a/page/options.html
+++ b/page/options.html
@@ -186,7 +186,7 @@
             </li>
             <li>
                 <label class="item">
-                    <div class="item-content">图片解析<div class="item-content-tip">重新解析图片，目前支持 3 种方式：图片URL、![]()、&lt;img /&gt;</div></div>
+                    <div class="item-content">图片解析<div class="item-content-tip">不限定图床，并支持 3 种方式：图片URL、![]()、&lt;img /&gt;</div></div>
                     <div class="item-secondary dropdownMenu">
                         <select name="imageParsing" id="imageParsing">
                             <option value="auto-hide">自动隐藏原始回复（默认）</option>

--- a/page/options.js
+++ b/page/options.js
@@ -70,7 +70,8 @@ const defaultSettings = {
     "sov2ex": 0,
     "customNode": "www",
     "base64": 0,
-    "darkTheme": 0
+    "darkTheme": 0,
+    "imageParsing": "auto-hide"
 };
 
 window.onload = function() {
@@ -98,7 +99,8 @@ window.onload = function() {
         sov2ex: document.querySelector(".sov2ex"),
         customNode: document.getElementById("customNode"),
         base64: document.querySelector(".base64"),
-        darkTheme: document.querySelector(".darkTheme")
+        darkTheme: document.querySelector(".darkTheme"),
+        imageParsing: document.getElementById("imageParsing")
     };
     
     function resetAll() {
@@ -128,6 +130,15 @@ window.onload = function() {
                     setItemByKey(name,value);//如果用户从未改过，则设置一个默认值
                     button.onchange = function(e) {
                         //console.log(e, this, this.value);
+                        let hex = this.value.toLowerCase();
+                        setItemByKey(name, hex);
+                    };
+                    button.disabled = false;
+                    break;
+                case "imageParsing":
+                    button.value = value;
+                    setItemByKey(name,value);//如果用户从未改过，则设置一个默认值
+                    button.onchange = function(e) {
                         let hex = this.value.toLowerCase();
                         setItemByKey(name, hex);
                     };

--- a/v2ex_reply.css
+++ b/v2ex_reply.css
@@ -249,6 +249,12 @@ span[class^="inputBTN"]:hover
 
 /* used by image parser */
 
+.original-reply{
+    background-color: #f2f2f2;
+    padding: 3px;
+    border-radius: 2px;
+}
+
 p.reply-separator {
     color: #696969;
     overflow: hidden;

--- a/v2ex_reply.css
+++ b/v2ex_reply.css
@@ -249,14 +249,18 @@ span[class^="inputBTN"]:hover
 
 /* used by image parser */
 
-p.reply-seperator {
+p.reply-separator {
     color: #696969;
     overflow: hidden;
     text-align: center;
+    font-size: x-small;
+    cursor: pointer;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
-p.reply-seperator:before,
-p.reply-seperator:after{
+p.reply-separator:before,
+p.reply-separator:after{
     background-color: #ccc;
     content: "";
     display: inline-block;
@@ -266,12 +270,12 @@ p.reply-seperator:after{
     width: 50%;
 }
 
-p.reply-seperator:before{
+p.reply-separator:before{
     right: 0.2em;
     margin-left: -50%;
 }
 
-p.reply-seperator:after {
+p.reply-separator:after {
     left: 0.2em;
     margin-right: -50%;
 }

--- a/v2ex_reply.css
+++ b/v2ex_reply.css
@@ -246,3 +246,32 @@ span[class^="inputBTN"]:hover
 .gist{
     white-space: normal !important;
 }
+
+/* used by image parser */
+
+p.reply-seperator {
+    color: #696969;
+    overflow: hidden;
+    text-align: center;
+}
+
+p.reply-seperator:before,
+p.reply-seperator:after{
+    background-color: #ccc;
+    content: "";
+    display: inline-block;
+    height: 1px;
+    position: relative;
+    vertical-align: middle;
+    width: 50%;
+}
+
+p.reply-seperator:before{
+    right: 0.2em;
+    margin-left: -50%;
+}
+
+p.reply-seperator:after {
+    left: 0.2em;
+    margin-right: -50%;
+}

--- a/v2ex_reply.js
+++ b/v2ex_reply.js
@@ -742,3 +742,165 @@ if (location.protocol == "https:"){
 }
 
 //——————————————————————————————————https 新浪图床修改——————————————————————————————————
+
+
+
+//——————————————————————————————————重新解析图片——————————————————————————————————
+/*
+默认情况下，v2ex中的评论只渲染来自imgur/weibo/v2ex的图片URL，用户体验非常不好。
+需要解决两个问题：
+1. 图床限制
+2. 非标准的图片URL，以下是需要转换的URL
+  - https://imgur.com/s9vHWcC
+  - not starts with https://
+*/
+var regex_common_imgurl = /\/.+\.(jpeg|jpg|gif|png)$/;
+function is_common_img_url(url){ // 常见的图片URL
+    return(url.match(regex_common_imgurl) != null);
+}
+
+var regex_imgur_imgurl = /^https?:\/\/imgur\.com\/[a-zA-Z0-9]{7}$/;
+function is_imgur_url(url){ // 是否属于imgur的图片URL
+    return (url.match(regex_imgur_imgurl) != null);
+}
+
+function is_img_url(url){
+    return (is_common_img_url(url) || is_imgur_url(url));
+}
+
+function has_img_url(text){
+    return (
+        regex_common_imgurl.test(text) ||
+        regex_imgur_imgurl.test(text)
+    );
+}
+
+function convert_img_url(url){
+    url = url.replace(/ /g, '');
+    // https://imgur.com/s9vHWcC
+    if(is_imgur_url(url)){
+        url += ".png";
+    }
+    if(is_img_url(url)){
+        // not starts with `http`
+        if(!(
+            url.startsWith('//') || 
+            url.startsWith('http://') ||
+            url.startsWith('https://')
+        )){
+            url = 'https://' + url;
+        }
+    }
+    return url;
+}
+
+
+var regex_url = /((http(s)?:)?\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+function replacer_url2img(match, offset, string){
+    if(is_common_img_url(match)){
+        let t = "<a href=\"" + match + "\">" + 
+            "<img target=\"_blank\" src=\"" + match + "\" alt=\"" + match + "\"/>" + 
+        "</a>";
+        return t;
+    }
+    return match;
+}
+
+var regex_mdimg = /(?:!\[(.*?)\]\s*\((.*?)\))/g;
+function replacer_mdimg2htmlimg(match, p1, p2, offset, string){
+    p2 = convert_img_url(p2);
+    if(is_common_img_url(p2)){
+        show_parsed = true;
+        let t = "<a href=\"" + p2 + "\">" + 
+                "<img target=\"_blank\" src=\"" + p2 + "\" alt=\"" + p1 + "\"/>" + 
+            "</a>"
+        return t;
+    }
+    return match;
+}
+
+
+var regex_html_imgtag = /&lt;img.*?src="(.*?)"[^\>]*&gt;/g;
+function replacer_plainimgtag2imgtag(match, p, offset, string){
+    p = convert_img_url(p);
+    return `<img src="${p}"/>`;
+}
+/*
+针对每个回复，拷贝其html，并作如下处理：
+1. 恢复出原始文本
+  1.1 用<img>中的src替换<img>
+  1.2 用<a>中的text替换<a>
+
+2. 重新解析文本
+  2.1 转换markdown格式的图片: `![]()` -> <img />
+  2.2 转换escaped <img>格式的图片: `&lt;img &gt;` -> <img />
+  2.3 转换plain image url: *.jpg -> <img />
+
+3. 判断是否展示
+*/
+
+var show_parsed = false;
+var replies = $('.reply_content');
+let i = 0, n_replies = replies.length;
+for(; i < n_replies; i++){ // for each reply
+
+    let reply = $(replies[i]),
+        reply_copy = reply.clone(true, true),
+        j = 0;
+    show_parsed = false;
+
+    // 1. 恢复出原始文本
+    // 1.1 用<img>中的src替换<img>
+    let imgs = $(reply_copy).find('img'),
+        n_imgs = imgs.length;
+    for(j = 0; j < n_imgs; j++){
+        let img = $(imgs[j]),
+            img_url = img.attr('src');
+        img.replaceWith(img_url);
+    }
+    // 1.2 用<a>中的text替换<a>
+    let links = $(reply_copy).find('a'),
+        n_links = links.length;
+    for(j = 0; j < n_links; j++){
+        let a = $(links[j]),
+            href = a.attr('href'),
+            text = a.text();
+        text = text.replace(/ /g, '');
+        if(is_img_url(href) && is_img_url(text)){ // or less strict: has_img_url(text)
+            url = convert_img_url(text);
+            a.replaceWith(url);
+        }
+    }
+
+    // 2. 重新解析文本
+    let html = $(reply_copy).html();
+    // 2.1 转换markdown格式的图片![]()
+    html = html.replace(regex_mdimg, replacer_mdimg2htmlimg);
+    $(reply_copy).html(html);
+    // 2.2 转换html <img>格式的图片<img />
+    html = html.replace(regex_html_imgtag, replacer_plainimgtag2imgtag);
+    $(reply_copy).html(html);
+    // 2.3 转换plain image url
+    let contents = $(reply_copy).contents(),
+        n_contents = contents.length;
+    for(j = 0; j < contents.length; j++){
+        let content = $(contents[j]);
+        if (content[0].nodeType == 3) {// text
+            let text = $(content).text();
+            if(regex_url.test(text)){
+                text = text.replace(regex_url, replacer_url2img);
+                $(contents[j]).replaceWith(text);
+
+            }
+        }
+    }
+
+    // 3. 判断是否展示
+    let seperator_html= `<p class="reply-seperator">Parsed by <a href="https://github.com/sciooga/v2ex-plus">v2ex plus</a></p>`;
+    if(show_parsed || reply.find('img').length < reply_copy.find('img').length){
+        reply.append(seperator_html);
+        reply.append(reply_copy.contents());
+    }
+
+
+}

--- a/v2ex_reply.js
+++ b/v2ex_reply.js
@@ -800,9 +800,7 @@ function convert_img_url(url){
 var regex_url = /((http(s)?:)?\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
 function replacer_url2img(match, offset, string){
     if(is_common_img_url(match)){
-        let t = "<a href=\"" + match + "\">" + 
-            "<img target=\"_blank\" src=\"" + match + "\" alt=\"" + match + "\"/>" + 
-        "</a>";
+        let t = `<a target="_blank" href="${match}"><img src="${match}" /></a>`;
         return t;
     }
     return match;
@@ -813,9 +811,7 @@ function replacer_mdimg2htmlimg(match, p1, p2, offset, string){
     p2 = convert_img_url(p2);
     if(is_common_img_url(p2)){
         show_parsed = true;
-        let t = "<a href=\"" + p2 + "\">" + 
-                "<img target=\"_blank\" src=\"" + p2 + "\" alt=\"" + p1 + "\"/>" + 
-            "</a>"
+        let t = `<a target="_blank" href="${p2}"><img src="${p2}" alt="${p1}" /></a>`;
         return t;
     }
     return match;
@@ -824,7 +820,7 @@ function replacer_mdimg2htmlimg(match, p1, p2, offset, string){
 var regex_html_imgtag = /&lt;img.*?src="(.*?)"[^\>]*&gt;/g;
 function replacer_plainimgtag2imgtag(match, p, offset, string){
     p = convert_img_url(p);
-    return `<img src="${p}"/>`;
+    return `<a target="_blank" href="${p}"><img src="${p}" /></a>`;
 }
 
 function construct_separator_html(id, tip){ // tip: 显示/隐藏

--- a/v2ex_reply.js
+++ b/v2ex_reply.js
@@ -754,42 +754,41 @@ if (location.protocol == "https:"){
   - not starts with https://
 */
 
-
 // Helper functions
 var regex_common_imgurl = /\/.+\.(jpeg|jpg|gif|png)$/;
-function is_common_img_url(url){ // 常见的图片URL
-    return(url.match(regex_common_imgurl) != null);
+function is_common_img_url(url) { // 常见的图片URL
+    return (url.match(regex_common_imgurl) != null);
 }
 
 var regex_imgur_imgurl = /^https?:\/\/imgur\.com\/[a-zA-Z0-9]{7}$/;
-function is_imgur_url(url){ // 是否属于imgur的图片URL
+function is_imgur_url(url) { // 是否属于imgur的图片URL
     return (url.match(regex_imgur_imgurl) != null);
 }
 
-function is_img_url(url){
+function is_img_url(url) {
     return (is_common_img_url(url) || is_imgur_url(url));
 }
 
-function has_img_url(text){
+function has_img_url(text) {
     return (
         regex_common_imgurl.test(text) ||
         regex_imgur_imgurl.test(text)
     );
 }
 
-function convert_img_url(url){
+function convert_img_url(url) {
     url = url.replace(/ /g, '');
     // https://imgur.com/s9vHWcC
-    if(is_imgur_url(url)){
+    if (is_imgur_url(url)) {
         url += ".png";
     }
-    if(is_img_url(url)){
+    if (is_img_url(url)) {
         // not starts with `http`
-        if(!(
-            url.startsWith('//') || 
-            url.startsWith('http://') ||
-            url.startsWith('https://')
-        )){
+        if (!(
+                url.startsWith('//') ||
+                url.startsWith('http://') ||
+                url.startsWith('https://')
+            )) {
             url = 'https://' + url;
         }
     }
@@ -798,8 +797,8 @@ function convert_img_url(url){
 
 
 var regex_url = /((http(s)?:)?\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
-function replacer_url2img(match, offset, string){
-    if(is_common_img_url(match)){
+function replacer_url2img(match, offset, string) {
+    if (is_common_img_url(match)) {
         let t = `<a target="_blank" href="${match}"><img src="${match}" /></a>`;
         return t;
     }
@@ -807,9 +806,9 @@ function replacer_url2img(match, offset, string){
 }
 
 var regex_mdimg = /(?:!\[(.*?)\]\s*\((.*?)\))/g;
-function replacer_mdimg2htmlimg(match, p1, p2, offset, string){
+function replacer_mdimg2htmlimg(match, p1, p2, offset, string) {
     p2 = convert_img_url(p2);
-    if(is_common_img_url(p2)){
+    if (is_common_img_url(p2)) {
         show_parsed = true;
         let t = `<a target="_blank" href="${p2}"><img src="${p2}" alt="${p1}" /></a>`;
         return t;
@@ -818,17 +817,17 @@ function replacer_mdimg2htmlimg(match, p1, p2, offset, string){
 }
 
 var regex_html_imgtag = /&lt;img.*?src="(.*?)"[^\>]*&gt;/g;
-function replacer_plainimgtag2imgtag(match, p, offset, string){
+function replacer_plainimgtag2imgtag(match, p, offset, string) {
     p = convert_img_url(p);
     return `<a target="_blank" href="${p}"><img src="${p}" /></a>`;
 }
 
-function construct_separator_html(id, tip){ // tip: 显示/隐藏
+function construct_separator_html(id, tip) { // tip: 显示/隐藏
     let html_part1 = `<p class="reply-separator">`,
         html_part2 = `</p>`;
-    return html_part1 + 
-            `（本回复已由<a href="https://github.com/sciooga/v2ex-plus"> v2ex plus </a>重新解析）<a class="toggle_original_reply_link" reply-id="${id}">点击此处${tip}原始回复</a>`
-        + html_part2;
+    return html_part1 +
+        `（本回复已由<a href="https://github.com/sciooga/v2ex-plus"> v2ex plus </a>重新解析）<a class="toggle_original_reply_link" reply-id="${id}">点击此处${tip}原始回复</a>` +
+        html_part2;
 }
 
 
@@ -849,16 +848,18 @@ function construct_separator_html(id, tip){ // tip: 显示/隐藏
 3. 判断是否展示
 */
 
-chrome.storage.sync.get("imageParsing", function (settings){
-    var imageParsing = settings['imageParsing'];
-    if(imageParsing == 'off'){
+chrome.storage.sync.get("imageParsing", function(settings) {
+    var imageParsing = settings["imageParsing"];
+    if (imageParsing == "off") {
         return;
     }
 
     var show_parsed = false;
-    var replies = $('.reply_content');
-    let i = 0, n_replies = replies.length;
-    for(; i < n_replies; i++){ // for each reply
+    var replies = $(".reply_content");
+    let i = 0,
+        n_replies = replies.length;
+    for (; i < n_replies; i++) {
+        // for each reply
 
         let reply = $(replies[i]),
             reply_copy = reply.clone(true, true),
@@ -866,23 +867,24 @@ chrome.storage.sync.get("imageParsing", function (settings){
         show_parsed = false;
 
         // 1. 恢复出原始文本
-        // 1.1 用<img>中的src替换<img>
-        let imgs = $(reply_copy).find('img'),
+
+        let imgs = $(reply_copy).find("img"),
             n_imgs = imgs.length;
-        for(j = 0; j < n_imgs; j++){
+        for (j = 0; j < n_imgs; j++) { // 1.1 用<img>中的src替换<img>
             let img = $(imgs[j]),
-                img_url = img.attr('src');
+                img_url = img.attr("src");
             img.replaceWith(img_url);
         }
-        // 1.2 用<a>中的text替换<a>
-        let links = $(reply_copy).find('a'),
+        
+        let links = $(reply_copy).find("a"),
             n_links = links.length;
-        for(j = 0; j < n_links; j++){
+        for (j = 0; j < n_links; j++) { // 1.2 用<a>中的text替换<a>
             let a = $(links[j]),
-                href = a.attr('href'),
+                href = a.attr("href"),
                 text = a.text();
-            text = text.replace(/ /g, '');
-            if(is_img_url(href) && is_img_url(text)){ // or less strict: has_img_url(text)
+            text = text.replace(/ /g, "");
+            if (is_img_url(href) && is_img_url(text)) {
+                // or less strict: has_img_url(text)
                 url = convert_img_url(text);
                 a.replaceWith(url);
             }
@@ -890,60 +892,63 @@ chrome.storage.sync.get("imageParsing", function (settings){
 
         // 2. 重新解析文本
         let html = $(reply_copy).html();
-        // 2.1 转换markdown格式的图片![]()
-        html = html.replace(regex_mdimg, replacer_mdimg2htmlimg);
+        html = html.replace(regex_mdimg, replacer_mdimg2htmlimg); // 2.1 转换markdown格式的图片![]()
         $(reply_copy).html(html);
-        // 2.2 转换html <img>格式的图片<img />
-        html = html.replace(regex_html_imgtag, replacer_plainimgtag2imgtag);
+        
+        html = html.replace(regex_html_imgtag, replacer_plainimgtag2imgtag); // 2.2 转换html <img>格式的图片<img />
         $(reply_copy).html(html);
-        // 2.3 转换plain image url
-        let contents = $(reply_copy).contents(),
-            n_contents = contents.length;
-        for(j = 0; j < contents.length; j++){
+        
+        let contents = $(reply_copy).contents();
+        for (j = 0; j < contents.length; j++) { // 2.3 转换plain image url
             let content = $(contents[j]);
-            if (content[0].nodeType == 3) {// text
+            if (content[0].nodeType == 3) {
+                // text
                 let text = $(content).text();
-                if(regex_url.test(text)){
+                if (regex_url.test(text)) {
                     text = text.replace(regex_url, replacer_url2img);
                     $(contents[j]).replaceWith(text);
-
                 }
             }
         }
 
         // 3. 判断是否展示
-        if(show_parsed || reply.find('img').length < reply_copy.find('img').length){
-
-            reply.wrapInner(`<div id="original-reply-${i}" class="original-reply"></div>`);
-            if(imageParsing == 'auto-hide'){
+        if (
+            show_parsed ||
+            reply.find("img").length < reply_copy.find("img").length
+        ) {
+            reply.wrapInner(
+                `<div id="original-reply-${i}" class="original-reply"></div>`
+            );
+            if (imageParsing == "auto-hide") {
                 $(`#original-reply-${i}`).toggle(false);
             }
 
             reply.append(`<div id="reply-separator-${i}-display"></div>`);
             reply.append(`<div id="reply-separator-${i}-hide"></div>`);
-            $(`#reply-separator-${i}-display`).html(construct_separator_html(i, "显示"));
-            $(`#reply-separator-${i}-hide`).html(construct_separator_html(i, "隐藏"));
-            if(imageParsing == 'auto-hide'){
+            $(`#reply-separator-${i}-display`).html(
+                construct_separator_html(i, "显示")
+            );
+            $(`#reply-separator-${i}-hide`).html(
+                construct_separator_html(i, "隐藏")
+            );
+            if (imageParsing == "auto-hide") {
                 $(`#reply-separator-${i}-display`).toggle(true);
                 $(`#reply-separator-${i}-hide`).toggle(false);
-            }
-            else{
+            } else {
                 $(`#reply-separator-${i}-display`).toggle(false);
                 $(`#reply-separator-${i}-hide`).toggle(true);
             }
-            
 
             reply_copy.wrapInner(`<div id="parsed-reply${i}"></div>`);
             reply.append(reply_copy.contents());
         }
     }
 
-    $(".toggle_original_reply_link").click(function (e){
+    $(".toggle_original_reply_link").click(function(e) {
         setTimeout(() => {
             let target = $(e.target),
-                id = target.attr("reply-id"),
-                div_id = `#original-reply-${id}`;
-            $(div_id).toggle();
+                id = target.attr("reply-id");
+            $(`#original-reply-${id}`).toggle();
             $(`#reply-separator-${id}-display`).toggle();
             $(`#reply-separator-${id}-hide`).toggle();
         }, 100);


### PR DESCRIPTION
默认情况下，v2ex中的评论只渲染来自imgur/weibo/v2ex的图片URL，用户体验非常不好。
需要解决两个问题：
1. 图床限制
2. 非标准的图片URL，以下是需要转换的URL
  - https://imgur.com/s9vHWcC
  - not starts with https://

故需要对回复中的内容重新解析，下面是处理步骤：
```
针对每个回复，拷贝其html，并作如下处理：
1. 恢复出原始文本
  1.1 用<img>中的src替换<img>
  1.2 用<a>中的text替换<a>
2. 重新解析文本
  2.1 转换markdown格式的图片: `![]()` -> <img />
  2.2 转换escaped <img>格式的图片: `&lt;img &gt;` -> <img />
  2.3 转换plain image url: *.jpg -> <img />
3. 判断是否展示
```

效果：
以这个帖子 [https://www.v2ex.com/t/634003](https://www.v2ex.com/t/634003) 为例，三个页面被重新解析的回复个数分别是：29+28+29=86

目前还没有添加用户选项对此功能的个性化设定，现在想看一下各位的意见，如果可以 merge 的话，我再加入用户选项。