### PR TITLE
Modify symbols whose meaning is not clearly expressed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ npm-debug.log
 deployments.log
 yarn-error.log
 package-lock.json
+yarn.lock
 lerna-debug.log
 .prettierrc
 

--- a/v2ex_reply.js
+++ b/v2ex_reply.js
@@ -36,7 +36,7 @@ function input_img(input_img_base64, this_img_id){
     _upload_image.append("<div class='imgId"+ this_img_id +"'>\
                                 <div><img src='"+ input_img_base64 +"' alt='上传图片'/></div>\
                                 <span>上传中</span>\
-                          </div>");
+                        </div>");
     _upload_image.slideDown(700);
 
     const img_base64 = input_img_base64.match("base64,(.*)")[1];
@@ -52,7 +52,7 @@ function input_img(input_img_base64, this_img_id){
             alert("图片上传失败，可能是未登录微博/受 imgur 上传次数限制");
             _img_preview.find("span").text("请重新上传");
         }
-        _upload_img_btn.text(" › 插入图片");
+        _upload_img_btn.text(" ᕀ 插入图片");
     });
 }
 
@@ -82,7 +82,7 @@ $("div[id^=r_]").each(function(){
     });
 
     function lazyGist(element) {
-        
+
     }
     //———回复空格修复———
 
@@ -465,7 +465,7 @@ var _reply_textarea = $("#reply_content");
 _reply_textarea.attr("placeholder", "你可以在文本框内直接粘贴截图或拖拽图片上传\n类似于 [:微笑:] 的图片标签可以优雅的移动");
 
 var _reply_textarea_top_btn = _reply_textarea.parents(".box").children(".cell:first-of-type");
-_reply_textarea_top_btn.append("<span class='inputBTN1'> › 表情</span><span class='inputBTN2'> › 插入图片</span><input type='file' style='display: none' id='imgUpload' accept='image/*' />");
+_reply_textarea_top_btn.append("<span class='inputBTN1'> ᕀ 表情</span><span class='inputBTN2'> ᕀ 插入图片</span><input type='file' style='display: none' id='imgUpload' accept='image/*' />");
 
 $("script").each(function(){
     var $this = $(this);
@@ -875,7 +875,7 @@ chrome.storage.sync.get("imageParsing", function(settings) {
                 img_url = img.attr("src");
             img.replaceWith(img_url);
         }
-        
+
         let links = $(reply_copy).find("a"),
             n_links = links.length;
         for (j = 0; j < n_links; j++) { // 1.2 用<a>中的text替换<a>
@@ -894,10 +894,10 @@ chrome.storage.sync.get("imageParsing", function(settings) {
         let html = $(reply_copy).html();
         html = html.replace(regex_mdimg, replacer_mdimg2htmlimg); // 2.1 转换markdown格式的图片![]()
         $(reply_copy).html(html);
-        
+
         html = html.replace(regex_html_imgtag, replacer_plainimgtag2imgtag); // 2.2 转换html <img>格式的图片<img />
         $(reply_copy).html(html);
-        
+
         let contents = $(reply_copy).contents();
         for (j = 0; j < contents.length; j++) { // 2.3 转换plain image url
             let content = $(contents[j]);


### PR DESCRIPTION
## 修改内容

1. 将输入框上方的 ` › 表情 ` 与 ` › 插入图片 ` 改为 ` ᕀ 表情 ` 与 ` ᕀ 插入图片 ` 
  - 修改前
    ![image](https://user-images.githubusercontent.com/38807139/72659118-c7cb9480-39f5-11ea-9fe6-3219469c7fe1.png)

  - 修改后
    ![image](https://user-images.githubusercontent.com/38807139/72659079-1593cd00-39f5-11ea-8e2c-f7cb1fce79e4.png)

**修改原因**：在使用过程中，发现使用 " › " 符号会带来歧义，下意识的会认为`添加一条新回复`、`表情`与`插入图片`三项存在层级递进关系，虽不影响使用，但对于用户体验有些许影响，所以使用 " ᕀ " 符号（**注**：不是" + " 符号）予以替换，且能呼应上传/添加的功能逻辑

2. 将 `yarn.lock` 文件添加到 `.gitignore` 文件中