### PR TITLE
Permission typo fix, web request filter fix for header modification in recent version Chrome

### DIFF
--- a/background.js
+++ b/background.js
@@ -644,6 +644,6 @@ chrome.webRequest.onBeforeSendHeaders.addListener(function (details) {
     types: ["image"],
     urls: ["*://*.sinaimg.cn/*"]
 },
-["blocking"]
+["blocking", "requestHeaders", chrome.webRequest.OnSendHeadersOptions.EXTRA_HEADERS]
 );
 //———————————————————————————————正常显示新浪图床图片——————————————————————————————

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "storage",
     "contextMenus",
     "webRequest",
-    "webBlockRequest",
+    "webRequestBlocking",
     "*://*.v2ex.com/*",
     "*://*.imgur.com/*",
     "*://*.weibo.com/*",


### PR DESCRIPTION
It seems a typo for `webRequestBlocking` permission. Please verify the manifest. Chrome API doc: https://developer.chrome.com/extensions/webRequest

Also, in recent version Chrome, to modify headers, `requestHeaders` filter is required, to modify referer, `EXTRA_HEADERS` must be specified.